### PR TITLE
fixed error of not hiding filter from prelude in HigherOrderProblems.hs

### DIFF
--- a/assignments/week4/hw/src/HigherOrderProblems.hs
+++ b/assignments/week4/hw/src/HigherOrderProblems.hs
@@ -1,7 +1,7 @@
 module HigherOrderProblems where
 
 -- this forces you to work with our more annoying lists, DO NOT CHANGE THE FOLLOWING 2 LINES
-import Prelude hiding (map, foldr, length) 
+import Prelude hiding (map, foldr, length, filter) 
 import AnnoyingLists
 
 


### PR DESCRIPTION
Like commit title, just changed it so that filter is hidden as if it wasn't haskell will get confused.