### PR TITLE
Fixed an error with pairs that caused pattern matching errors with values and list of values.

### DIFF
--- a/assignments/week4/hw/src/IndexTree.hs
+++ b/assignments/week4/hw/src/IndexTree.hs
@@ -43,7 +43,7 @@ keys  = undefined
 
 
 -- pairs returns a list of (key,value) pairs for each in the index tree in any order
-pairs :: (IndexTree k v)  -> [(k,v)]
+pairs :: (IndexTree k v)  -> [(k,[v])]
 pairs  = undefined
 
 


### PR DESCRIPTION
Changing this made the code work on my computer because it did not know that v was a list, but just a single element.